### PR TITLE
Add pipeline to build and publish on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+    GH_TOKEN: ${{ github.token }}
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A minimalistic pipeline to build on release and add the artifact to the release.

This makes releases accessible via:
`https://github.com/tboye/offbeat.amsterdam/releases/download/{version}/offbeat_amsterdam-v{version}.tgz`

In case it's the latest release, `download/{version}` can be replaced by `download/latest`.

OFF-64