### PR TITLE
Fix info/ticket panel is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.6 (17-07-2025)
+## Fix
+- Fix hydration issue breaking info/ticket panel [#16](https://github.com/tboye/offbeat.amsterdam/pull/16)
+
 # 0.6.5 (14-07-2025)
 ## Fix
 - Fix structured event data is inconsistent between event page and event cards [#15](https://github.com/tboye/offbeat.amsterdam/pull/15)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offbeat_amsterdam",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A fork of Gancio by lesion, with modifications for offbeat.amsterdam.",
   "author": "lesion",
   "contributors": ["tboye"],

--- a/pages/event/_slug.vue
+++ b/pages/event/_slug.vue
@@ -41,8 +41,8 @@
             v-list-item(v-for="(url, index) in formattedOnlineLocations" :key="index" target="_blank" :href="url.href")
               v-list-item-icon
                 v-icon(v-text="url.icon")
-              v-list-item-content.py-0
-                v-list-item-title.text-caption(v-html="url.label")
+              v-list-item-content.text-uppercase
+                v-list-item-title(v-text="$t(url.label)")
 
           v-divider
           //- info & actions
@@ -299,9 +299,7 @@ export default {
       return this.event.online_locations.map((url, index) => ({
         href: url,
         icon: index === 0 ? mdiInformation : index === 1 ? mdiTicketConfirmationOutline : mdiLinkVariant,
-        label: index === 0 ? `<a href="${url}" target="_blank">Info</a>`
-          : index === 1 ? `<a href="${url}" target="_blank">Tickets</a>`
-            : `<a href="${url}" target="_blank">${url}</a>`
+        label: index === 0 ? "Info" : index === 1 ? "Tickets" : url
       }))
     },
     isOnline() {


### PR DESCRIPTION
Fixes hydration bug on the event page that showed up only when visiting directly. Turns out `v-html` inside `v-list-item-title` was messing with SSR. Switched to plain text and cleaned up the structure so that Vue could hydrate in peace.

OFF-274